### PR TITLE
Fix icons, move recipes into public/recipes.json

### DIFF
--- a/public/recipes.json
+++ b/public/recipes.json
@@ -1,0 +1,74 @@
+{
+  "results": [
+    {
+      "name": "Chicken Korma",
+      "type": "Indian",
+      "rating": 8,
+      "cal": 500,
+      "cost": 4
+    },
+    {
+      "name": "Chicken Biryani",
+      "type": "Indian",
+      "rating": 9.3,
+      "cal": 280,
+      "cost": 4.3
+    },
+    {
+      "name": "Kung Pao Chicken",
+      "type": "Chinese",
+      "rating": 8.5,
+      "cal": 220,
+      "cost": 6
+    },
+    {
+      "name": "Scallion Pancakes",
+      "type": "Chinese",
+      "rating": 7.5,
+      "cal": 180,
+      "cost": 4.3
+    },
+    {
+      "name": "Korean Fried Cauliflour",
+      "type": "Korean",
+      "rating": 9.5,
+      "cal": 280,
+      "cost": 3.9
+    },
+    {
+      "name": "Korean Chili Paste",
+      "type": "Korean",
+      "rating": 10,
+      "cal": 15,
+      "cost": 3.9
+    },
+    {
+      "name": "Pork Carnitas",
+      "type": "Mexican",
+      "rating": 7.5,
+      "cal": 180,
+      "cost": 4.3
+    },
+    {
+      "name": "Fajitas",
+      "type": "Mexican-TexMex",
+      "rating": 8,
+      "cal": 180,
+      "cost": 4.3
+    },
+    {
+      "name": "Curry Chicken Salad",
+      "type": "American-Asian Fusion",
+      "rating": 10,
+      "cal": 150,
+      "cost": 4.3
+    },
+    {
+      "name": "Chicken Fried Steak",
+      "type": "American",
+      "rating": 8.5,
+      "cal": 400,
+      "cost": 4.3
+    }
+  ]
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,8 @@
+html, body, #root, .App {
+  height: 100%;
+  width: 100%;
+}
+
 body {
   background-color: #61dafb;
 }
@@ -12,4 +17,18 @@ body {
 .MuiTableHead-root {
   background-color: #61dafb;
   color: white;
+}
+
+.App {
+  display: flex;
+  flex-direction: column;
+}
+
+.tableSect {
+  flex: 1 0 auto;
+}
+
+.Logo {
+  flex-shrink: 0;
+  text-align: center;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,6 @@ import heroPic from "./Components/images/mexicanfood.png";
 import "./App.css";
 import EnhancedTable from "./Components/MaterialUI/tables";
 import Logo from "./Components/logo";
-import GitHubIcon from "@material-ui/icons/GitHub";
 
 function App() {
   return (

--- a/src/App.js
+++ b/src/App.js
@@ -1,23 +1,43 @@
-import React from "react";
+import React, { Component } from "react";
 import heroPic from "./Components/images/mexicanfood.png";
 import "./App.css";
 import EnhancedTable from "./Components/MaterialUI/tables";
 import Logo from "./Components/logo";
+import Axios from "axios";
 
-function App() {
-  return (
-    <div className="App">
-      <header className="App-header">
-        <img src={heroPic} className="heroPic" alt="logo" />
-      </header>
-      <section className="tableSect">
-        <EnhancedTable />
-      </section>
-      <section className="Logo">
-        <Logo />
-      </section>
-    </div>
-  );
+
+export default class react extends Component {
+
+  state = {
+    recipes: []
+  }
+
+  async componentDidMount() {
+    let recipes = [];
+    try {
+      const { data } = await Axios.get('/recipes.json');
+      recipes = data.results;
+      this.setState({ recipes });
+    } catch (error) {
+      console.error('something went wrong!', error);
+    }
+
+  }
+
+  render() {
+    const { recipes } = this.state;
+    return (
+      <div className="App">
+        <header className="App-header">
+          <img src={heroPic} className="heroPic" alt="logo" />
+        </header>
+        <section className="tableSect">
+          <EnhancedTable rows={recipes} />
+        </section>
+        <section className="Logo">
+          <Logo />
+        </section>
+      </div>
+    );
+  }
 }
-
-export default App;

--- a/src/Components/MaterialUI/tables.js
+++ b/src/Components/MaterialUI/tables.js
@@ -19,146 +19,6 @@ import Tooltip from "@material-ui/core/Tooltip";
 import DeleteIcon from "@material-ui/icons/Delete";
 import FilterListIcon from "@material-ui/icons/FilterList";
 
-function createData(name, type, rating, cal, cost) {
-  return { name, type, rating, cal, cost };
-}
-//The data in rows should be DishName / Type of Cuisine / Rating / Calories / Price Per Serving / Ingredence List / Actual Recipe
-const rows = [
-  createData(
-    "Chicken Korma",
-    "Indian",
-    8,
-    500,
-    4.0,
-    ["Chicken", "Cashews", "Rice", "Ghee", "Spices"],
-    ["step1", "step2", "step3", "step 4"]
-  ),
-  createData(
-    "Chicken Biryani",
-    "Indian",
-    9.3,
-    280,
-    4.3,
-    ["Chicken", "Saffron", "Rice", "Ghee", "Spices"],
-    ["step1", "step2", "step3", "step 4"]
-  ),
-  createData(
-    "Kung Pao Chicken",
-    "Chinese",
-    8.5,
-    220,
-    6.0,
-    [
-      "Chicken",
-      "Shecuan Peppers",
-      "Peanuts",
-      "Celery",
-      "Sesame Oil",
-      "Zuchinis",
-      "Rice",
-    ],
-    ["step1", "step2", "step3", "step 4"]
-  ),
-  createData(
-    "Scallion Pancakes",
-    "Chinese",
-    7.5,
-    180,
-    4.3,
-    ["Scallions", "Flour", "Soy Sauce", "Seasame Oil", "Eggs"],
-    ["step1", "step2", "step3", "step 4"]
-  ),
-  createData(
-    "Korean Fried Cauliflour",
-    "Korean",
-    9.5,
-    280,
-    3.9,
-    [
-      "Cauliflower",
-      "Tempora Batter",
-      "Korean Chili Paste",
-      "Lime",
-      "Green Onion",
-    ],
-    ["step1", "step2", "step3", "step 4"]
-  ),
-  createData(
-    "Korean Chili Paste",
-    "Korean",
-    10,
-    15,
-    3.9,
-    [
-      "Gochujang",
-      "Kalbi",
-      "Korean Chili Paste",
-      "Kecap Manis",
-      "Honey",
-      "Garlic",
-      "Ginger",
-      "Sugar",
-      "Apple Cider Vinegar",
-      "Seasame Oil",
-      "Siracha",
-    ],
-    [
-      "Place all ingredients into a blender and process until incorporated and smooth, scraping the sides occasionally to ensure even blending.",
-    ]
-  ),
-  createData(
-    "Pork Carnitas",
-    "Mexican",
-    7.5,
-    180,
-    4.3,
-    [
-      "Pork Butt",
-      "Chipotle Peppers",
-      "Chicken Stock",
-      "Onion",
-      "Garlic",
-      "Spices",
-    ],
-    ["step1", "step2", "step3", "step 4"]
-  ),
-  createData(
-    "Fajitas",
-    "Mexican-TexMex",
-    8,
-    180,
-    4.3,
-    ["Skirt Steak", "Yellow Onion", "Bell Pepper", "Salt and Pepper"],
-    ["step1", "step2", "step3", "step 4"]
-  ),
-  createData(
-    "Curry Chicken Salad",
-    "American-Asian Fusion",
-    10,
-    150,
-    4.3,
-    [
-      "Chicken Breast",
-      "Mayo",
-      "Curry Powder",
-      "Salt and Pepper",
-      "Raisins",
-      "Celery",
-      "Cashews",
-      "Fuji Apples",
-    ],
-    ["step1", "step2", "step3", "step 4"]
-  ),
-  createData(
-    "Chicken Fried Steak",
-    "American",
-    8.5,
-    400,
-    4.3,
-    ["Skirt Steak", "Flour", "Eggs", "Salt and Pepper"],
-    ["step1", "step2", "step3", "step 4"]
-  ),
-];
 
 function descendingComparator(a, b, orderBy) {
   if (b[orderBy] < a[orderBy]) {
@@ -374,7 +234,9 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function EnhancedTable() {
+export default function EnhancedTable({ rows }) {
+  console.log(rows);
+
   const classes = useStyles();
   const [order, setOrder] = React.useState("asc");
   const [orderBy, setOrderBy] = React.useState("type");

--- a/src/Components/logo.js
+++ b/src/Components/logo.js
@@ -7,12 +7,12 @@ import FeedbackIcon from "@material-ui/icons/Feedback";
 function Logo(props) {
   console.log(props);
   return (
-    <div>
-      <i className={GitHubIcon}>GitHubIcon</i>
-      <i className={DraftsIcon}>email</i>
-      <i className={LinkedInIcon}>LinkedIn</i>
-      <i className={FeedbackIcon}>Feedback</i>
-    </div>
+    <>
+      <GitHubIcon />
+      <DraftsIcon />
+      <LinkedInIcon />
+      <FeedbackIcon />
+    </>
   );
 }
 


### PR DESCRIPTION
## THE ASK
Need to fix up the footer and use ajax to get the recipes

## THE SOLUTION

- Material-ui icons can be used directly as components and do not need a wrapper.
- Used [https://css-tricks.com/couple-takes-sticky-footer/](some css tricks) to get the footer to be sticky
- Convert app.js into a class component so we can use componentDidMount and not mess around with functional component useEffect
- In the EnhancedTable component, we console.log'd the rows so we could easily copy them into `public/recipes.json`
- EnhancedTable now takes `rows` as a prop instead of having them hardcoded
- App makes an api request to get the recipes on initialization
- App passes the recipes to the EnhancedTable